### PR TITLE
Update bounce_driver.class.php

### DIFF
--- a/includes/helpers/bounce_driver.class.php
+++ b/includes/helpers/bounce_driver.class.php
@@ -226,7 +226,7 @@ class BounceHandler{
             //  Busted Exim MTA
             //  Up to 50 email addresses can be listed on each header.
             //  There can be multiple X-Failed-Recipients: headers. - (not supported)
-            $arrFailed = split(',', $this->head_hash['X-failed-recipients']);
+            $arrFailed = explode(',', $this->head_hash['X-failed-recipients']);
             for($j=0; $j<count($arrFailed); $j++){
                 $this->output[$j]['recipient'] = trim($arrFailed[$j]);
                 $this->output[$j]['status'] = $this->get_status_code_from_text($this->output[$j]['recipient'],0);


### PR DESCRIPTION
https://www.php.net/manual/en/function.split.php

Warning
This function was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0.

Fixed by using "explode"